### PR TITLE
feat: add support for highlight style and table of contents in Pandoc action

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -15,6 +15,14 @@ if [ -n "${PANDOC_LISTINGS}" ] && [ "${PANDOC_LISTINGS}" = "true" ]; then
     # Use --listings to include listings
     COMMAND="${COMMAND} --listings"
 fi
+if [ -n "${PANDOC_HIGHLIGHT_STYLE}" ]; then
+    # Use --highlight-style to specify the highlight style
+    COMMAND="${COMMAND} --highlight-style \"${PANDOC_HIGHLIGHT_STYLE}\""
+fi
+if [ -n "${PANDOC_TOC}" ] && [ "${PANDOC_TOC}" = "true" ]; then
+    # Use --toc to include a table of contents
+    COMMAND="${COMMAND} --toc"
+fi
 if [ -n "${PANDOC_PDF_ENGINE}" ]; then
     # Use --pdf-engine to specify the PDF engine
     COMMAND="${COMMAND} --pdf-engine ${PANDOC_PDF_ENGINE}"

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,14 @@ inputs:
     description: 'Whether to use the listings package'
     default: false
     type: boolean
+  highlight-style:
+    required: false
+    description: 'The highlight style to use'
+  toc:
+    required: false
+    description: 'Whether to include a table of contents'
+    default: false
+    type: boolean
   cjk-mainfont:
     required: false
     description: 'The main font for CJK characters (e.g. Noto Serif CJK JP)'
@@ -57,6 +65,8 @@ runs:
     PANDOC_PDF_ENGINE: ${{ inputs.pdf-engine }}
     PANDOC_TEMPLATE: ${{ inputs.template }}
     PANDOC_LISTINGS: ${{ inputs.listings }}
+    PANDOC_HIGHLIGHT_STYLE: ${{ inputs.highlight-style }}
+    PANDOC_TOC: ${{ inputs.toc }}
     PANDOC_CJK_MAINFONT: ${{ inputs.cjk-mainfont }}
     PANDOC_MAINFONT: ${{ inputs.mainfont }}
     PANDOC_SANSFONT: ${{ inputs.sansfont }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- Pandocコマンドのカスタマイズオプションを追加
		- ハイライトスタイルの指定が可能に
		- 目次の生成オプションを追加

- **設定の更新**
	- GitHub Actionの入力パラメータを拡張
		- オプションの`highlight-style`を追加
		- オプションの`toc`を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->